### PR TITLE
Add flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,41 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1654665288,
+        "narHash": "sha256-7blJpfoZEu7GKb84uh3io/5eSJNdaagXD9d15P9iQMs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "43ecbe7840d155fa933ee8a500fb00dbbc651fc8",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,20 @@
+{
+  description = "nix build file generator for rust crates";
+
+  inputs = {
+    utils.url = github:numtide/flake-utils;
+  };
+
+  outputs = { nixpkgs, utils, ... }:
+    utils.lib.eachDefaultSystem (system:
+      let pkgs = import nixpkgs { inherit system; };
+          crate2nix = import ./. { inherit pkgs; };
+       in
+      {
+        packages.default = crate2nix;
+        apps.default = {
+          type = "app";
+          program = "${crate2nix}/bin/crate2nix";
+        };
+      });
+}


### PR DESCRIPTION
Makes possible using crate2nix without explicitly installing it: `nix run github:Mr-Andersen/crate2nix -- generate`